### PR TITLE
feat: update debian version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 debian:bookworm-slim
+FROM --platform=linux/amd64 debian:stable-backports
 
 RUN apt-get update && apt-get install unzip openssl ca-certificates -y
 COPY ./jupiter-swap-api-x86_64-unknown-linux-gnu.zip ./jupiter-swap-api-x86_64-unknown-linux-gnu.zip


### PR DESCRIPTION
The old debian is now complaining with the following error:
```
❯ docker compose up
[+] Running 2/2
 ✔ Container jupiter-swap-api                                                                                                                                      Recreated0.2s
 ! jupiter-swap-api The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested 0.0s
Attaching to jupiter-swap-api
jupiter-swap-api  | ./jupiter-swap-api: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./jupiter-swap-api)
jupiter-swap-api exited with code 1
```