### PR TITLE
fix docker publish workflow to use the release zip for the tag being built

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,10 +23,10 @@ jobs:
       # 
     steps:
       - uses: actions/checkout@v4
-      - uses: dsaltares/fetch-gh-release-asset@master
+      - uses: dsaltares/fetch-gh-release-asset@1.1.2
         with:
           repo: ${{ github.repository }}
-          version: 'latest'
+          version: tags/${{ github.ref_name }}
           file: 'metis-binary-x86_64-unknown-linux-gnu.zip'
           token: ${{ secrets.GITHUB_TOKEN }}
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.


### PR DESCRIPTION
hey team, was looking at the publish workflow and noticed something off.

when you push a tag, the workflow tags the docker image with that tag (via metadata-action), but the step that downloads the binary zip uses `version: latest` instead of the tag that triggered the run. so if you ever rebuild an older tag, or releases get created out of order, you can end up with e.g. `ghcr.io/.../metis-binary:v7.0.10` that actually contains the v7.0.14 binary inside. pretty easy to miss until someone debugs a version mismatch in prod.

this changes it to `tags/${{ github.ref_name }}` so the zip always matches the tag push. also pinned fetch-gh-release-asset to 1.1.2 instead of `@master`.

cheers