### PR TITLE
[codex] fix docker publish image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,10 +23,10 @@ jobs:
       # 
     steps:
       - uses: actions/checkout@v4
-      - uses: dsaltares/fetch-gh-release-asset@master
+      - uses: dsaltares/fetch-gh-release-asset@1.1.2
         with:
           repo: ${{ github.repository }}
-          version: 'latest'
+          version: tags/${{ github.ref_name }}
           file: 'metis-binary-x86_64-unknown-linux-gnu.zip'
           token: ${{ secrets.GITHUB_TOKEN }}
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
       # 
     steps:
       - uses: actions/checkout@v4
-      - uses: dsaltares/fetch-gh-release-asset@1.1.2
+      - uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7
         with:
           repo: ${{ github.repository }}
           version: tags/${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
-FROM --platform=linux/amd64 debian:bookworm-slim
+FROM --platform=linux/amd64 debian:trixie-slim
 
-RUN apt-get update && apt-get install unzip openssl ca-certificates -y
-COPY ./metis-binary-x86_64-unknown-linux-gnu.zip ./metis-binary-x86_64-unknown-linux-gnu.zip
-RUN unzip metis-binary-x86_64-unknown-linux-gnu.zip
-RUN rm metis-binary-x86_64-unknown-linux-gnu.zip
-RUN chmod +x metis-binary
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip openssl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY metis-binary-x86_64-unknown-linux-gnu.zip .
+RUN unzip -q metis-binary-x86_64-unknown-linux-gnu.zip \
+    && rm metis-binary-x86_64-unknown-linux-gnu.zip \
+    && chmod +x metis-binary
 
 ENV RUST_LOG=info
 
-CMD ["./metis-binary"]
+CMD ["/app/metis-binary"]


### PR DESCRIPTION
## Summary

- Fetch the Linux release zip for the tag being published instead of `latest`
- Pin `dsaltares/fetch-gh-release-asset` to `1.1.2`
- Move the runtime image to `debian:trixie-slim` so the current Linux binary has the required glibc
- Keep the Dockerfile packaging path simple: unzip into `/app`, remove apt/cache/zip leftovers, run `/app/metis-binary`

## Root Cause

The publish workflow tags images from the pushed Git tag, but downloaded the `latest` release asset. Rebuilding an older tag could publish an image tag containing a newer binary.

The current `v7.0.16` Linux binary also requires `GLIBC_2.38`, which is not available in `debian:bookworm-slim`. The image built, but the binary failed at runtime.

## Validation

- `git diff --check -- Dockerfile .github/workflows/publish.yaml`
- Built `metis-binary:dogfood` from the real `v7.0.16` `metis-binary-x86_64-unknown-linux-gnu.zip` release asset
- Confirmed `bookworm-slim` runtime failed with missing `GLIBC_2.38`
- Confirmed `trixie-slim` runtime starts the binary
- Dogfooded the container with local market cache:
  - `GET /program-id-to-label` returned `200`
  - `GET /ready` returned `READY`
  - `GET /metrics` returned `200`
  - `GET /quote` for SOL -> USDC returned `200` with a route

## Notes

Default Europa market loading still failed locally with `401 Unauthorized`; that appears to be the local Metis API key, not the Docker image.
